### PR TITLE
Remove support for unsafe setups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,18 +7,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: iffy/install-nim@v1
-    - name: Install Linux Dependencies
-      if: runner.os == 'Linux'
-      run: sudo apt-get -y install libdbus-1-dev gnome-keyring
     - name: Build
       run: nimble build -y
     - name: Test
-      if: runner.os != 'Linux'
       run: nimble test -y
-    - name: Linux Test
-      if: runner.os == 'Linux'
-      run: dbus-run-session -- bash -c 'echo "" | gnome-keyring-daemon --unlock && nimble test'

--- a/mine.nimble
+++ b/mine.nimble
@@ -11,7 +11,6 @@ if defined(macosx):
 requires "nim >= 1.0.6 & < 2.0.0"
 requires "sss >= 0.2.1 & < 0.3.0"
 requires "mnemonic >= 0.1.3 & < 0.2.0"
-requires "keyring >= 0.2.1 & < 0.3.0"
 requires "monocypher >= 0.1.2 & < 0.2.0"
 requires "docopt >= 0.6.8 & < 0.7.0"
 requires "tempfile >= 0.1.7 & < 0.2.0"

--- a/mine.nimble
+++ b/mine.nimble
@@ -5,6 +5,9 @@ license = "MIT"
 
 bin = @["mine"]
 
+if defined(macosx):
+  backend = "objc"
+
 requires "nim >= 1.0.6 & < 2.0.0"
 requires "sss >= 0.2.1 & < 0.3.0"
 requires "mnemonic >= 0.1.3 & < 0.2.0"

--- a/mine.nimble
+++ b/mine.nimble
@@ -7,6 +7,11 @@ bin = @["mine"]
 
 if defined(macosx):
   backend = "objc"
+else:
+  backend = "c"
+
+task test, "Runs the test suite":
+  exec "nim " & backend & " --run --path:. --define:test tests/testRunner"
 
 requires "nim >= 1.0.6 & < 2.0.0"
 requires "sss >= 0.2.1 & < 0.3.0"

--- a/minepkg/storage.nim
+++ b/minepkg/storage.nim
@@ -1,14 +1,10 @@
-import ./secrets
-import keyring
-import os
+import secrets
+import storage/raw
 import base64
 import options
 
-proc getAppName: string =
-  getAppFilename().extractFilename()
-
 proc retrieveSecret*(name: string): Option[Secret] =
-  let retrieved = getPassword(getAppName(), name)
+  let retrieved = retrieveString(name)
   if retrieved.isNone:
     return none(Secret)
   var decoded = decode(retrieved.get())
@@ -19,7 +15,7 @@ proc retrieveSecret*(name: string): Option[Secret] =
 
 proc storeSecret*(name: string, secret: Secret) =
   assert retrieveSecret(name).isNone
-  setPassword(getAppName(), name, encode(secret))
+  storeString(name, encode(secret))
 
 proc deleteSecret*(name: string) =
-  deletePassword(getAppName(), name)
+  deleteString(name)

--- a/minepkg/storage/macos.nim
+++ b/minepkg/storage/macos.nim
@@ -1,14 +1,109 @@
+{.passL: "-framework Security".}
+
 import os
-import keyring
+import options
+
+{.emit: """
+
+#import <Foundation/Foundation.h>;
+#import <Security/Security.h>;
+
+bool setPassword(char *service, char *account, char *value, uint size) {
+  @autoreleasepool{
+    NSString *serviceString =
+      [NSString stringWithCString:service encoding: NSUTF8StringEncoding];
+    NSString *accountString =
+      [NSString stringWithCString:account encoding: NSUTF8StringEncoding];
+    NSData *valueData =
+      [NSData dataWithBytes:value length:size];
+
+    OSStatus result = SecItemAdd(@{
+      (id)kSecClass: (id)kSecClassGenericPassword,
+      (id)kSecAttrService: serviceString,
+      (id)kSecAttrAccount: accountString,
+      (id)kSecValueData: valueData
+    }, nil);
+
+    if (result == errSecDuplicateItem) {
+      result = SecItemUpdate(@{
+        (id)kSecClass: (id)kSecClassGenericPassword,
+        (id)kSecAttrService: serviceString,
+        (id)kSecAttrAccount: accountString,
+        (id)kSecMatchLimit: (id)kSecMatchLimitOne,
+        (id)kSecReturnData: @NO
+      }, @{
+        (id)kSecValueData: valueData
+      });
+    }
+
+    return (result == errSecSuccess);
+  }
+}
+
+int getPassword(char *service, char *account, char *buffer, uint bufferSize) {
+  @autoreleasepool{
+    NSString *serviceString =
+      [NSString stringWithCString:service encoding: NSUTF8StringEncoding];
+    NSString *accountString =
+      [NSString stringWithCString:account encoding: NSUTF8StringEncoding];
+
+    NSData *result;
+
+    SecItemCopyMatching(@{
+      (id)kSecClass: (id)kSecClassGenericPassword,
+      (id)kSecAttrService: serviceString,
+      (id)kSecAttrAccount: accountString,
+      (id)kSecMatchLimit: (id)kSecMatchLimitOne,
+      (id)kSecReturnData: @YES
+    }, &result);
+
+    if (result == nil) {
+      return -1;
+    }
+
+    [result getBytes:buffer length:bufferSize];
+    return result.length;
+  }
+}
+
+bool deletePassword(char *service, char *account) {
+  @autoreleasepool{
+    NSString *serviceString =
+      [NSString stringWithCString:service encoding: NSUTF8StringEncoding];
+    NSString *accountString =
+      [NSString stringWithCString:account encoding: NSUTF8StringEncoding];
+
+    OSStatus result = SecItemDelete(@{
+      (id)kSecClass: (id)kSecClassGenericPassword,
+      (id)kSecAttrService: serviceString,
+      (id)kSecAttrAccount: accountString
+    });
+
+    return (result == errSecSuccess);
+  }
+}
+
+"""}
+
+proc setPassword(service, account, value: cstring, size: uint): bool
+                {.importc, nodecl.}
+proc getPassword(service, account: cstring, buffer: ptr char,
+                 bufferSize: uint): int {.importc, nodecl.}
+proc deletePassword(service, account: cstring): bool {.importc, nodecl.}
 
 proc getAppName: string =
   getAppFilename().extractFilename()
 
 proc retrieveString*(name: string): Option[string] =
-  getPassword(getAppName(), name)
+  var buffer: array[4096, char]
+  let size = getPassword(getAppName(), name, addr buffer[0], buffer.len.uint)
+  if size == -1:
+    result = none[string]()
+  else:
+    result = some(cast[string](buffer[0..<size]))
 
 proc storeString*(name: string, value: string) =
-  setPassword(getAppName(), name, value)
+  assert setPassword(getAppName(), name, value, value.len.uint)
 
 proc deleteString*(name: string) =
-  deletePassword(getAppName(), name)
+  discard deletePassword(getAppName(), name)

--- a/minepkg/storage/macos.nim
+++ b/minepkg/storage/macos.nim
@@ -17,7 +17,7 @@ bool setPassword(char *service, char *account, char *value, uint size) {
     NSData *valueData =
       [NSData dataWithBytes:value length:size];
 
-    OSStatus result = SecItemAdd(@{
+    OSStatus result = SecItemAdd((__bridge CFDictionaryRef)@{
       (id)kSecClass: (id)kSecClassGenericPassword,
       (id)kSecAttrService: serviceString,
       (id)kSecAttrAccount: accountString,
@@ -25,13 +25,13 @@ bool setPassword(char *service, char *account, char *value, uint size) {
     }, nil);
 
     if (result == errSecDuplicateItem) {
-      result = SecItemUpdate(@{
+      result = SecItemUpdate((__bridge CFDictionaryRef)@{
         (id)kSecClass: (id)kSecClassGenericPassword,
         (id)kSecAttrService: serviceString,
         (id)kSecAttrAccount: accountString,
         (id)kSecMatchLimit: (id)kSecMatchLimitOne,
         (id)kSecReturnData: @NO
-      }, @{
+      }, (__bridge CFDictionaryRef)@{
         (id)kSecValueData: valueData
       });
     }
@@ -47,9 +47,9 @@ int getPassword(char *service, char *account, char *buffer, uint bufferSize) {
     NSString *accountString =
       [NSString stringWithCString:account encoding: NSUTF8StringEncoding];
 
-    NSData *result;
+    CFTypeRef result = nil;
 
-    SecItemCopyMatching(@{
+    SecItemCopyMatching((__bridge CFDictionaryRef)@{
       (id)kSecClass: (id)kSecClassGenericPassword,
       (id)kSecAttrService: serviceString,
       (id)kSecAttrAccount: accountString,
@@ -61,8 +61,9 @@ int getPassword(char *service, char *account, char *buffer, uint bufferSize) {
       return -1;
     }
 
-    [result getBytes:buffer length:bufferSize];
-    return result.length;
+    NSData *data = (__bridge NSData *)result;
+    [data getBytes:buffer length:bufferSize];
+    return (int)data.length;
   }
 }
 
@@ -73,7 +74,7 @@ bool deletePassword(char *service, char *account) {
     NSString *accountString =
       [NSString stringWithCString:account encoding: NSUTF8StringEncoding];
 
-    OSStatus result = SecItemDelete(@{
+    OSStatus result = SecItemDelete((__bridge CFDictionaryRef)@{
       (id)kSecClass: (id)kSecClassGenericPassword,
       (id)kSecAttrService: serviceString,
       (id)kSecAttrAccount: accountString

--- a/minepkg/storage/macos.nim
+++ b/minepkg/storage/macos.nim
@@ -1,0 +1,14 @@
+import os
+import keyring
+
+proc getAppName: string =
+  getAppFilename().extractFilename()
+
+proc retrieveString*(name: string): Option[string] =
+  getPassword(getAppName(), name)
+
+proc storeString*(name: string, value: string) =
+  setPassword(getAppName(), name, value)
+
+proc deleteString*(name: string) =
+  deletePassword(getAppName(), name)

--- a/minepkg/storage/qubes.nim
+++ b/minepkg/storage/qubes.nim
@@ -1,0 +1,39 @@
+import options
+import os
+import parsecfg
+
+proc getAppName: string =
+  getAppFilename().extractFilename()
+
+proc getConfigFilename: string =
+  getConfigDir() / "mine.ini"
+
+proc loadConfig: Config =
+  if existsFile(getConfigFilename()):
+    result = loadConfig(getConfigFilename())
+  else:
+    result = newConfig()
+
+proc writeConfig(config: Config) =
+  let creating = not existsFile(getConfigFilename())
+  writeConfig(config, getConfigFilename())
+  if creating:
+    setFilePermissions(getConfigFilename(), {fpUserWrite, fpUserRead})
+
+proc retrieveString*(name: string): Option[string] =
+  let config = loadConfig()
+  let value = config.getSectionValue(getAppName(), name)
+  if value == "":
+    result = none[string]()
+  else:
+    result = some(value)
+
+proc storeString*(name: string, value: string) =
+  var config = loadConfig()
+  config.setSectionKey(getAppName(), name, value)
+  writeConfig(config)
+
+proc deleteString*(name: string) =
+  var config = loadConfig()
+  config.delSectionKey(getAppName(), name)
+  writeConfig(config)

--- a/minepkg/storage/raw.nim
+++ b/minepkg/storage/raw.nim
@@ -1,0 +1,6 @@
+when defined(macosx):
+  import macos
+  export macos
+elif defined(linux):
+  import qubes
+  export qubes

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,20 @@ Mine̼, a password and key manager
 
 Warning: this is highly experimental. Do not use for real passwords and keys!
 
+Installation
+------------
+
+Currently only macOS and Qubes OS are supported.
+
+To install, download these sources and compile them with a recent version of [Nim][1] using the command `nimble build`.
+
+On macOS, you can now use the `mine` binary using the instructions below.
+
+On Qubes OS, you should only run the `mine` binary in the `vault` VM. Make
+sure that you move the `mine` binary to the `vault` VM before use.
+
+[1]: https://nim-lang.org
+
 Command Line Usage
 ------------------
 

--- a/tests/helpers/stdin.nim
+++ b/tests/helpers/stdin.nim
@@ -5,13 +5,7 @@ import minepkg/console
 template redirect*(body: untyped) =
   block:
     let (file, filename) = mkstemp(mode=fmRead)
-    defer:
-      close(file)
-      removeFile(filename)
-
     let redirected {.inject.} = open(filename, fmWrite, bufSize = 0)
-    defer:
-      close(redirected)
 
     let saved = console.input
     console.input = file
@@ -19,3 +13,7 @@ template redirect*(body: untyped) =
     body
 
     console.input = saved
+
+    close(redirected)
+    close(file)
+    removeFile(filename)

--- a/tests/helpers/stdout.nim
+++ b/tests/helpers/stdout.nim
@@ -6,13 +6,7 @@ import minepkg/console
 template redirect*(body: untyped) =
   block:
     let (file, filename) = mkstemp(mode=fmWrite)
-    defer:
-      close(file)
-      removeFile(filename)
-
     let redirected {.inject.} = open(filename)
-    defer:
-      close(redirected)
 
     let saved = console.output
     console.output = file
@@ -20,3 +14,7 @@ template redirect*(body: untyped) =
     body
 
     console.output = saved
+
+    close(file)
+    close(redirected)
+    removeFile(filename)

--- a/tests/mine/testQubesStorage.nim
+++ b/tests/mine/testQubesStorage.nim
@@ -1,0 +1,18 @@
+import unittest
+import os
+import minepkg/storage/raw
+
+when defined(linux):
+
+  suite "qubes storage":
+
+    setup:
+      storeString("someName", "some value")
+
+    teardown:
+      deleteString("someName")
+
+    test "creates config file with correct permissions":
+      let filename = getConfigDir() / "mine.ini"
+      check existsFile(filename)
+      check getFilePermissions(filename) == {fpUserRead, fpUserWrite}

--- a/tests/mine/testQubesStorage.nim
+++ b/tests/mine/testQubesStorage.nim
@@ -1,8 +1,8 @@
-import unittest
-import os
-import minepkg/storage/raw
-
 when defined(linux):
+
+  import unittest
+  import os
+  import minepkg/storage/raw
 
   suite "qubes storage":
 

--- a/tests/mine/testStorage.nim
+++ b/tests/mine/testStorage.nim
@@ -1,6 +1,5 @@
 import unittest
 import options
-import os
 import base64
 import minepkg/storage/raw
 import mine

--- a/tests/mine/testStorage.nim
+++ b/tests/mine/testStorage.nim
@@ -1,13 +1,13 @@
 import unittest
 import options
-import keyring
 import os
 import base64
+import minepkg/storage/raw
 import mine
 
 suite "storage":
 
-  let name = "some name"
+  let name = "someName"
   let secret = createRootKey().deriveSecret(name)
 
   teardown:
@@ -21,12 +21,12 @@ suite "storage":
     check retrieveSecret("non-existing").isNone
 
   test "refuses to retrieve a secret that's not base64":
-    setPassword(getAppFilename().extractFilename(), name, "not base64!")
+    storeString(name, "not base64!")
     expect Exception:
       discard retrieveSecret(name)
 
   test "refuses to retrieve a secret of the wrong length":
-    setPassword(getAppFilename().extractFilename(), name, encode("too short"))
+    storeString(name, encode("too short"))
     expect Exception:
       discard retrieveSecret(name)
 

--- a/tests/testRunner.nim
+++ b/tests/testRunner.nim
@@ -2,6 +2,7 @@ import mine/testRoot
 import mine/testSecrets
 import mine/testBackup
 import mine/testStorage
+import mine/testQubesStorage
 import mine/testConsole
 import mine/testPasswords
 import mine/testMnemonics


### PR DESCRIPTION
Only support environments where the main secret can be safely kept. This includes macOS with a password on the keychain item, and Qubes OS with `mine` running inside the vault.

Removes the 'keyring' dependency.